### PR TITLE
Non-cuDNN layers

### DIFF
--- a/beacon8/layers/SpatialConvolution.py
+++ b/beacon8/layers/SpatialConvolution.py
@@ -1,0 +1,41 @@
+from .Module import Module
+
+import theano as _th
+import numpy as _np
+
+
+class SpatialConvolution(Module):
+    def __init__(self, n_input_plane, n_output_plane, k_w, k_h, d_w=1, d_h=1, with_bias=True, border_mode='valid', imshape=None):
+        Module.__init__(self)
+        self.n_input_plane = n_input_plane
+        self.n_output_plane = n_output_plane
+        self.k_w = k_w
+        self.k_h = k_h
+        self.d_w = d_w
+        self.d_h = d_h
+        self.with_bias = with_bias
+        self.border_mode = border_mode
+        self.imshape = imshape
+
+        w_bound = _np.sqrt(4. / ((self.n_input_plane + self.n_output_plane) * self.k_w * self.k_h))
+        W = _np.random.uniform(low=-w_bound, high=w_bound, size=(n_output_plane, n_input_plane, k_h, k_w))
+        self.weight = _th.shared(W.astype(dtype=_th.config.floatX))
+        self.grad_weight = _th.shared((W*0).astype(dtype=_th.config.floatX))
+
+        if self.with_bias:
+            self.bias = _th.shared(_np.zeros(shape=(n_output_plane, ), dtype=_th.config.floatX))
+            self.grad_bias = _th.shared(_np.zeros(shape=(n_output_plane, ), dtype=_th.config.floatX))
+
+    def symb_forward(self, symb_input):
+        conv_output = _th.tensor.nnet.conv.conv2d(symb_input, self.weight,
+            image_shape=(None, self.n_input_plane) + (self.imshape or (None, None)),
+            filter_shape=(self.n_output_plane, self.n_input_plane, self.k_h, self.k_w),
+            border_mode=self.border_mode,
+            subsample=(self.d_h, self.d_w)
+        )
+
+        if self.with_bias:
+            return conv_output + self.bias.dimshuffle('x', 0, 'x', 'x')
+        else:
+            return conv_output
+

--- a/beacon8/layers/SpatialMaxPooling.py
+++ b/beacon8/layers/SpatialMaxPooling.py
@@ -1,0 +1,33 @@
+from .Module import Module
+
+import theano.tensor as _T
+
+
+class SpatialMaxPooling(Module):
+    def __init__(self, k_w, k_h, d_w=None, d_h=None, pad_w=0, pad_h=0, ignore_border=False):
+        Module.__init__(self)
+        self.k_w = k_w
+        self.k_h = k_h
+        self.ignore_border = ignore_border
+
+        if d_w is None:
+            self.d_w = self.k_w
+        else:
+            self.d_w = d_w
+
+        if d_h is None:
+            self.d_h = self.k_h
+        else:
+            self.d_h = d_h
+
+        self.pad_w = pad_w
+        self.pad_h = pad_h
+
+    def symb_forward(self, symb_input):
+        return _T.signal.downsample.max_pool_2d(
+            symb_input,
+            ds=(self.k_h, self.k_w),
+            ignore_border=self.ignore_border,
+            st=(self.d_h, self.d_w),
+            padding=(self.pad_h, self.pad_w)
+        )

--- a/beacon8/layers/__init__.py
+++ b/beacon8/layers/__init__.py
@@ -8,5 +8,7 @@ from .Dropout import *
 from .AddConstant import *
 from .Log import *
 from .Reshape import *
+from .SpatialConvolution import *
+from .SpatialMaxPooling import *
 from .SpatialConvolutionCUDNN import *
 from .SpatialMaxPoolingCUDNN import *


### PR DESCRIPTION
I wanted to experiment on my laptop while traveling, but cuDNN doesn't support its GPU. So here are the default Theano versions of conv and max-pool.

Note that I don't keep the same interface, just keep it consistent; e.g. conv is missing the padding parameter because it's not supported. I don't think we should try to make them identical as otherwise there's no reason in having both anymore.

The `padding` option to max-pool requires Theano 0.7, but since it's officially out already, I think it's ok to have it as a requirement.
