### PR TITLE
Don't compile/call function when there's no stats to be accumulated.

### DIFF
--- a/beacon8/layers/BatchNormalization.py
+++ b/beacon8/layers/BatchNormalization.py
@@ -42,7 +42,7 @@ class BatchNormalization(Module):
         else:
             return symb_input * self.inference_weight.dimshuffle(*d_shuffle) + self.inference_bias.dimshuffle(*d_shuffle)
 
-    def get_stat_updates(self,):
+    def get_stat_updates(self):
         assert (self.batch_mean is not None) and (self.batch_var is not None), "You need to do a forward pass first"
 
         stat_updates = list()

--- a/beacon8/layers/Module.py
+++ b/beacon8/layers/Module.py
@@ -81,6 +81,10 @@ class Module:
             self.symb_forward(symb_in)
 
             stat_updates = self.get_stat_updates()
+            if not stat_updates:
+                # If there's no layer collecting statistics, we don't need to
+                # compile and call a function. This prevents theano errors.
+                return
 
             self.fn_accum_stats = _th.function(
                 inputs=[symb_in],


### PR DESCRIPTION
Without this, the examples that _don't_ use `BatchNormalization` (like the `net()` in MNIST) will given an error when `model.accumulate_statistics` is called in `train(..., 'stats')`. Just for reference, here's the error message:

```
  File "examples/MNIST/run.py", line 32, in <module>
    main(params)
  File "examples/MNIST/run.py", line 22, in main
    train(train_set_x, train_set_y, model, optimiser, criterion, epoch, params['batch_size'], 'stats')
  File "/home/beyer/academic/Beacon8/examples/MNIST/train.py", line 23, in train
    model.accumulate_statistics(mini_batch_input)
  File "/home/beyer/academic/Beacon8/beacon8/layers/Module.py", line 87, in accumulate_statistics
    updates=stat_updates
  File "/home/beyer/sci-env3/lib/python3.3/site-packages/Theano-0.7.0-py3.3.egg/theano/compile/function.py", line 309, in function
    output_keys=output_keys)
  File "/home/beyer/sci-env3/lib/python3.3/site-packages/Theano-0.7.0-py3.3.egg/theano/compile/pfunc.py", line 522, in pfunc
    output_keys=output_keys)
  File "/home/beyer/sci-env3/lib/python3.3/site-packages/Theano-0.7.0-py3.3.egg/theano/compile/function_module.py", line 1522, in orig_function
    output_keys=output_keys).create(
  File "/home/beyer/sci-env3/lib/python3.3/site-packages/Theano-0.7.0-py3.3.egg/theano/compile/function_module.py", line 1168, in __init__
    self._check_unused_inputs(inputs, outputs, on_unused_input)
  File "/home/beyer/sci-env3/lib/python3.3/site-packages/Theano-0.7.0-py3.3.egg/theano/compile/function_module.py", line 1301, in _check_unused_inputs
    i.variable, err_msg))
theano.compile.function_module.UnusedInputError: theano.function was asked to create a function computing outputs given certain inputs, but the provided input variable at index 0 is not part of the computational graph needed to compute the outputs: X.
To make this error into a warning, you can pass the parameter on_unused_input='warn' to theano.function. To disable it completely, use on_unused_input='ignore'.
```
