### PR TITLE
Factor out progress-bar to examples.utils.

### DIFF
--- a/examples/Kaggle-Otto/progress_bar.py
+++ b/examples/Kaggle-Otto/progress_bar.py
@@ -1,7 +1,0 @@
-from progressbar import ProgressBar, Counter, Percentage, Bar, ETA
-
-
-def make_progressbar(mode, epoch, data_size):
-    widgets = [mode + ' epoch #', str(epoch), ', processed ', Counter(), ' of ', str(data_size),
-               ' (', Percentage(), ')', ' ', Bar(), ' ', ETA()]
-    return ProgressBar(maxval=data_size, widgets=widgets)

--- a/examples/Kaggle-Otto/run.py
+++ b/examples/Kaggle-Otto/run.py
@@ -43,6 +43,9 @@ def nnet():
     return model
 
 if __name__ == "__main__":
+    if __package__ is None:  # PEP366
+        __package__ = "beacon8.examples.KaggleOtto"
+
     train_data_x, train_data_y = load_train_data()
 
     train_data_x, test_data_x, train_data_y, test_data_y = train_test_split(train_data_x, train_data_y, train_size=0.85)

--- a/examples/Kaggle-Otto/test.py
+++ b/examples/Kaggle-Otto/test.py
@@ -6,7 +6,7 @@ from kaggle_utils import *
 from examples.utils import make_progressbar
 
 def validate(dataset_x, dataset_y, model, epoch, batch_size):
-    progress = make_progressbar('Testing', epoch, len(dataset_x))
+    progress = make_progressbar('Testing epoch #{}'.format(epoch), len(dataset_x))
     progress.start()
 
     mini_batch_input = np.empty(shape=(batch_size, 93), dtype=_th.config.floatX)

--- a/examples/Kaggle-Otto/test.py
+++ b/examples/Kaggle-Otto/test.py
@@ -1,8 +1,9 @@
 import numpy as np
-from progress_bar import *
 import theano as _th
 from sklearn.metrics import log_loss
 from kaggle_utils import *
+
+from examples.utils import make_progressbar
 
 def validate(dataset_x, dataset_y, model, epoch, batch_size):
     progress = make_progressbar('Testing', epoch, len(dataset_x))

--- a/examples/Kaggle-Otto/train.py
+++ b/examples/Kaggle-Otto/train.py
@@ -1,7 +1,7 @@
 import numpy as np
-from progress_bar import *
 import theano as _th
 
+from examples.utils import make_progressbar
 
 def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, mode=None):
     progress = make_progressbar('Training', epoch, len(dataset_x))
@@ -24,6 +24,6 @@ def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, 
         else:
             model.accumulate_statistics(mini_batch_input)
 
-        progress.update(j * batch_size)
+        progress.update((j+1) * batch_size)
 
     progress.finish()

--- a/examples/Kaggle-Otto/train.py
+++ b/examples/Kaggle-Otto/train.py
@@ -4,7 +4,7 @@ import theano as _th
 from examples.utils import make_progressbar
 
 def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, mode=None):
-    progress = make_progressbar('Training', epoch, len(dataset_x))
+    progress = make_progressbar('Training epoch #{}'.format(epoch), len(dataset_x))
     progress.start()
 
     shuffle = np.random.permutation(len(dataset_x))

--- a/examples/MNIST/progress_bar.py
+++ b/examples/MNIST/progress_bar.py
@@ -1,7 +1,0 @@
-from progressbar import ProgressBar, Counter, Percentage, Bar, ETA
-
-
-def make_progressbar(mode, epoch, data_size):
-    widgets = [mode + ' epoch #', str(epoch), ', processed ', Counter(), ' of ', str(data_size),
-               ' (', Percentage(), ')', ' ', Bar(), ' ', ETA()]
-    return ProgressBar(maxval=data_size, widgets=widgets)

--- a/examples/MNIST/run.py
+++ b/examples/MNIST/run.py
@@ -26,6 +26,9 @@ def main(params):
 
 
 if __name__ == "__main__":
+    if __package__ is None:  # PEP366
+        __package__ = "beacon8.examples.MNIST"
+
     params = {}
     params['lr'] = 0.1
     params['batch_size'] = 64

--- a/examples/MNIST/test.py
+++ b/examples/MNIST/test.py
@@ -4,7 +4,7 @@ import theano as _th
 from examples.utils import make_progressbar
 
 def validate(dataset_x, dataset_y, model, epoch, batch_size):
-    progress = make_progressbar('Testing', epoch, len(dataset_x))
+    progress = make_progressbar('Testing epoch #{}'.format(epoch), len(dataset_x))
     progress.start()
 
     mini_batch_input = np.empty(shape=(batch_size, 28*28), dtype=_th.config.floatX)

--- a/examples/MNIST/test.py
+++ b/examples/MNIST/test.py
@@ -1,6 +1,7 @@
 import numpy as np
-from progress_bar import *
 import theano as _th
+
+from examples.utils import make_progressbar
 
 def validate(dataset_x, dataset_y, model, epoch, batch_size):
     progress = make_progressbar('Testing', epoch, len(dataset_x))

--- a/examples/MNIST/train.py
+++ b/examples/MNIST/train.py
@@ -1,6 +1,7 @@
 import numpy as np
-from progress_bar import *
 import theano as _th
+
+from examples.utils import make_progressbar
 
 
 def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, mode='train'):
@@ -26,6 +27,6 @@ def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, 
         else:
             assert False, "Mode should be either 'train' or 'stats'"
 
-        progress.update(j * batch_size)
+        progress.update((j+1) * batch_size)
 
     progress.finish()

--- a/examples/MNIST/train.py
+++ b/examples/MNIST/train.py
@@ -5,7 +5,7 @@ from examples.utils import make_progressbar
 
 
 def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, mode='train'):
-    progress = make_progressbar('Training ({})'.format(mode), epoch, len(dataset_x))
+    progress = make_progressbar('Training ({}) epoch #{}'.format(mode, epoch), len(dataset_x))
     progress.start()
 
     shuffle = np.random.permutation(len(dataset_x))

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -26,9 +26,10 @@ except ImportError:
         def update(self, i):
             _sys.stdout.write("\r" + self.fmt.format(i=i, tot=self.tot, pct=float(i)/self.tot))
             _sys.stdout.flush()
+            self.lasti = i
 
         def finish(self):
-            _sys.stdout.write("\r" + self.fmt.format(i=self.tot, tot=self.tot, pct=1.0) + "\n")
+            _sys.stdout.write("\r" + self.fmt.format(i=self.lasti, tot=self.tot, pct=1.0) + "\n")
             _sys.stdout.flush()
 
     def make_progressbar(mode, epoch, data_size):

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,0 +1,37 @@
+import sys as _sys
+
+
+# Progressbar
+##############
+
+
+try:
+    import progressbar as _pb
+
+    def make_progressbar(mode, epoch, data_size):
+        widgets = [mode + ' epoch #', str(epoch), ', processed ', _pb.Counter(), ' of ', str(data_size),
+                   ' (', _pb.Percentage(), ')', ' ', _pb.Bar(), ' ', _pb.ETA()]
+        return _pb.ProgressBar(maxval=data_size, widgets=widgets)
+
+except ImportError:
+
+    class SimpleProgressBar(object):
+        def __init__(self, tot, fmt):
+            self.tot = tot
+            self.fmt = fmt
+
+        def start(self):
+            self.update(0)
+
+        def update(self, i):
+            _sys.stdout.write("\r" + self.fmt.format(i=i, tot=self.tot, pct=float(i)/self.tot))
+            _sys.stdout.flush()
+
+        def finish(self):
+            _sys.stdout.write("\r" + self.fmt.format(i=self.tot, tot=self.tot, pct=1.0) + "\n")
+            _sys.stdout.flush()
+
+    def make_progressbar(mode, epoch, data_size):
+        return SimpleProgressBar(data_size,
+            "{} epoch #{}, processed {{i}} of {{tot}} ({{pct:.2%}})".format(mode, epoch)
+        )

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -8,8 +8,8 @@ import sys as _sys
 try:
     import progressbar as _pb
 
-    def make_progressbar(mode, epoch, data_size):
-        widgets = [mode + ' epoch #', str(epoch), ', processed ', _pb.Counter(), ' of ', str(data_size),
+    def make_progressbar(prefix, data_size):
+        widgets = [prefix, ', processed ', _pb.Counter(), ' of ', str(data_size),
                    ' (', _pb.Percentage(), ')', ' ', _pb.Bar(), ' ', _pb.ETA()]
         return _pb.ProgressBar(maxval=data_size, widgets=widgets)
 
@@ -32,7 +32,5 @@ except ImportError:
             _sys.stdout.write("\r" + self.fmt.format(i=self.lasti, tot=self.tot, pct=1.0) + "\n")
             _sys.stdout.flush()
 
-    def make_progressbar(mode, epoch, data_size):
-        return SimpleProgressBar(data_size,
-            "{} epoch #{}, processed {{i}} of {{tot}} ({{pct:.2%}})".format(mode, epoch)
-        )
+    def make_progressbar(prefix, data_size):
+        return SimpleProgressBar(data_size, prefix + ", processed {i} of {tot} ({pct:.2%})")


### PR DESCRIPTION
This also adds a fallback text-only "progressbar" in case the `progressbar` library is not available.

For example, I can't `pip install` it because of some (probably python version related) issue which I don't want to investigate now.

Note that it also corrects `j` to `j+1` in training progress.
