### PR TITLE
Kaggle otto minor revamp.

### DIFF
--- a/examples/Kaggle-Otto/run.py
+++ b/examples/Kaggle-Otto/run.py
@@ -59,8 +59,8 @@ if __name__ == "__main__":
         model.training()
         if epoch % 100 == 0:
             optimiser.hyperparams['lr'] /= 10
-        train(train_data_x, train_data_y, model, optimiser, criterion, epoch, 100)
-        train(train_data_x, train_data_y, model, optimiser, criterion, epoch, 100, 'stat')
+        train(train_data_x, train_data_y, model, optimiser, criterion, epoch, 100, 'train')
+        train(train_data_x, train_data_y, model, optimiser, criterion, epoch, 100, 'stats')
 
         model.evaluate()
         validate(test_data_x, test_data_y, model, epoch, 100)

--- a/examples/Kaggle-Otto/run.py
+++ b/examples/Kaggle-Otto/run.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
 
     train_data_x, train_data_y = load_train_data()
 
-    train_data_x, test_data_x, train_data_y, test_data_y = train_test_split(train_data_x, train_data_y, train_size=0.85)
+    train_data_x, valid_data_x, train_data_y, valid_data_y = train_test_split(train_data_x, train_data_y, train_size=0.85)
     model = nnet()
 
     criterion = bb8.ClassNLLCriterion()
@@ -63,5 +63,5 @@ if __name__ == "__main__":
         train(train_data_x, train_data_y, model, optimiser, criterion, epoch, 100, 'stats')
 
         model.evaluate()
-        validate(test_data_x, test_data_y, model, epoch, 100)
+        validate(valid_data_x, valid_data_y, model, epoch, 100)
 

--- a/examples/Kaggle-Otto/run.py
+++ b/examples/Kaggle-Otto/run.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import beacon8 as bb8
 import beacon8.optimizers as optim
+from os.path import dirname, join as pjoin
 from sklearn.preprocessing import LabelEncoder
 from sklearn.cross_validation import train_test_split
 from train import *
@@ -9,7 +10,7 @@ from test import *
 
 
 def load_train_data():
-    train_data = pd.read_csv('./data/train.csv')
+    train_data = pd.read_csv(pjoin(dirname(__file__), 'data', 'train.csv'))
     labels = train_data.target.values
     labels_encoder = LabelEncoder()
     labels = labels_encoder.fit_transform(labels)

--- a/examples/Kaggle-Otto/run.py
+++ b/examples/Kaggle-Otto/run.py
@@ -5,15 +5,14 @@ import beacon8.optimizers as optim
 from os.path import dirname, join as pjoin
 from sklearn.preprocessing import LabelEncoder
 from sklearn.cross_validation import train_test_split
-from train import *
-from test import *
+from train import train
+from test import validate
 
 
 def load_train_data():
     train_data = pd.read_csv(pjoin(dirname(__file__), 'data', 'train.csv'))
     labels = train_data.target.values
-    labels_encoder = LabelEncoder()
-    labels = labels_encoder.fit_transform(labels)
+    labels = LabelEncoder().fit_transform(labels)
     train_data = train_data.drop('id', axis=1)
     train_data = train_data.drop('target', axis=1)
     return train_data.as_matrix(), labels
@@ -56,9 +55,9 @@ if __name__ == "__main__":
 
     optimiser = optim.Momentum(lr=0.01, momentum=0.9)
 
-    for epoch in range(1000):
+    for epoch in range(1, 1001):
         model.training()
-        if epoch > 100 and epoch % 100 == 0:
+        if epoch % 100 == 0:
             optimiser.hyperparams['lr'] /= 10
         train(train_data_x, train_data_y, model, optimiser, criterion, epoch, 100)
         train(train_data_x, train_data_y, model, optimiser, criterion, epoch, 100, 'stat')

--- a/examples/Kaggle-Otto/test.py
+++ b/examples/Kaggle-Otto/test.py
@@ -1,8 +1,7 @@
 import numpy as np
 import theano as _th
-from sklearn.metrics import log_loss
-from kaggle_utils import *
 
+from kaggle_utils import multiclass_log_loss
 from examples.utils import make_progressbar
 
 def validate(dataset_x, dataset_y, model, epoch, batch_size):

--- a/examples/Kaggle-Otto/test.py
+++ b/examples/Kaggle-Otto/test.py
@@ -11,7 +11,7 @@ def validate(dataset_x, dataset_y, model, epoch, batch_size):
 
     mini_batch_input = np.empty(shape=(batch_size, 93), dtype=_th.config.floatX)
     mini_batch_targets = np.empty(shape=(batch_size, ), dtype=_th.config.floatX)
-    accuracy = 0.
+    logloss = 0.
 
     for j in range((dataset_x.shape[0] + batch_size - 1) // batch_size):
         progress.update(j * batch_size)
@@ -26,7 +26,7 @@ def validate(dataset_x, dataset_y, model, epoch, batch_size):
             mini_batch_prediction.resize((dataset_x.shape[0] - j * batch_size, 9))
             mini_batch_targets.resize((dataset_x.shape[0] - j * batch_size, ))
 
-        accuracy = accuracy + multiclass_log_loss(mini_batch_targets, mini_batch_prediction, normalize=False)
+        logloss += multiclass_log_loss(mini_batch_targets, mini_batch_prediction, normalize=False)
 
     progress.finish()
-    print("Epoch #" + str(epoch) + ", Logloss: " + str(float(accuracy) / dataset_x.shape[0]))
+    print("Epoch #{}, Logloss: {:.5f}".format(epoch, logloss/dataset_x.shape[0]))

--- a/examples/Kaggle-Otto/train.py
+++ b/examples/Kaggle-Otto/train.py
@@ -3,8 +3,9 @@ import theano as _th
 
 from examples.utils import make_progressbar
 
-def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, mode=None):
-    progress = make_progressbar('Training epoch #{}'.format(epoch), len(dataset_x))
+
+def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, mode='train'):
+    progress = make_progressbar('Training ({}) epoch #{}'.format(mode, epoch), len(dataset_x))
     progress.start()
 
     shuffle = np.random.permutation(len(dataset_x))
@@ -17,12 +18,14 @@ def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, 
             mini_batch_input[k] = dataset_x[shuffle[j * batch_size + k]]
             mini_batch_targets[k] = dataset_y[shuffle[j * batch_size + k]]
 
-        if mode is None:
+        if mode == 'train':
             model.zero_grad_parameters()
             model.accumulate_gradients(mini_batch_input, mini_batch_targets, criterion)
             optimiser.update_parameters(model)
-        else:
+        elif mode == 'stats':
             model.accumulate_statistics(mini_batch_input)
+        else:
+            assert False, "Mode should be either 'train' or 'stats'"
 
         progress.update((j+1) * batch_size)
 


### PR DESCRIPTION
Only minor stuff, mostly similar to the previous MNIST revamp, but now for the Kaggle-Otto example.

Again, it's easier to read the individual commits diffs, which each does only one thing.
