### PR TITLE
Make Indexing minibatches simpler thanks to numpy.

### DIFF
--- a/examples/Kaggle-Otto/test.py
+++ b/examples/Kaggle-Otto/test.py
@@ -1,5 +1,5 @@
 import numpy as np
-import theano as _th
+import theano as th
 
 from kaggle_utils import multiclass_log_loss
 from examples.utils import make_progressbar
@@ -8,24 +8,17 @@ def validate(dataset_x, dataset_y, model, epoch, batch_size):
     progress = make_progressbar('Testing epoch #{}'.format(epoch), len(dataset_x))
     progress.start()
 
-    mini_batch_input = np.empty(shape=(batch_size, 93), dtype=_th.config.floatX)
-    mini_batch_targets = np.empty(shape=(batch_size, ), dtype=_th.config.floatX)
     logloss = 0.
-
     for j in range((dataset_x.shape[0] + batch_size - 1) // batch_size):
-        progress.update(j * batch_size)
-        for k in range(batch_size):
-            if j * batch_size + k < dataset_x.shape[0]:
-                mini_batch_input[k] = dataset_x[j * batch_size + k]
-                mini_batch_targets[k] = dataset_y[j * batch_size + k]
+        # Note: numpy correctly handles the size of the last minibatch.
+        mini_batch_input = dataset_x[j*batch_size : (j+1)*batch_size].astype(th.config.floatX)
+        mini_batch_targets = dataset_y[j*batch_size : (j+1)*batch_size].astype(th.config.floatX)
 
         mini_batch_prediction = model.forward(mini_batch_input)
 
-        if (j + 1) * batch_size > dataset_x.shape[0]:
-            mini_batch_prediction.resize((dataset_x.shape[0] - j * batch_size, 9))
-            mini_batch_targets.resize((dataset_x.shape[0] - j * batch_size, ))
-
         logloss += multiclass_log_loss(mini_batch_targets, mini_batch_prediction, normalize=False)
+
+        progress.update(j * batch_size + len(mini_batch_input))
 
     progress.finish()
     print("Epoch #{}, Logloss: {:.5f}".format(epoch, logloss/dataset_x.shape[0]))

--- a/examples/Kaggle-Otto/train.py
+++ b/examples/Kaggle-Otto/train.py
@@ -1,5 +1,5 @@
 import numpy as np
-import theano as _th
+import theano as th
 
 from examples.utils import make_progressbar
 
@@ -10,13 +10,10 @@ def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, 
 
     shuffle = np.random.permutation(len(dataset_x))
 
-    mini_batch_input = np.empty(shape=(batch_size, 93), dtype=_th.config.floatX)
-    mini_batch_targets = np.empty(shape=(batch_size, ), dtype=_th.config.floatX)
-
     for j in range(dataset_x.shape[0] // batch_size):
-        for k in range(batch_size):
-            mini_batch_input[k] = dataset_x[shuffle[j * batch_size + k]]
-            mini_batch_targets[k] = dataset_y[shuffle[j * batch_size + k]]
+        indices = shuffle[j*batch_size : (j+1)*batch_size]
+        mini_batch_input = dataset_x[indices].astype(th.config.floatX)
+        mini_batch_targets = dataset_y[indices].astype(th.config.floatX)
 
         if mode == 'train':
             model.zero_grad_parameters()
@@ -27,6 +24,6 @@ def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, 
         else:
             assert False, "Mode should be either 'train' or 'stats'"
 
-        progress.update((j+1) * batch_size)
+        progress.update(j*batch_size + len(mini_batch_input))
 
     progress.finish()

--- a/examples/MNIST/test.py
+++ b/examples/MNIST/test.py
@@ -1,5 +1,5 @@
 import numpy as np
-import theano as _th
+import theano as th
 
 from examples.utils import make_progressbar
 
@@ -7,24 +7,17 @@ def validate(dataset_x, dataset_y, model, epoch, batch_size):
     progress = make_progressbar('Testing epoch #{}'.format(epoch), len(dataset_x))
     progress.start()
 
-    mini_batch_input = np.empty(shape=(batch_size, 28*28), dtype=_th.config.floatX)
-    mini_batch_targets = np.empty(shape=(batch_size, ), dtype=_th.config.floatX)
     nerrors = 0
-
     for j in range((dataset_x.shape[0] + batch_size - 1) // batch_size):
-        progress.update(j * batch_size)
-        for k in range(batch_size):
-            if j * batch_size + k < dataset_x.shape[0]:
-                mini_batch_input[k] = dataset_x[j * batch_size + k]
-                mini_batch_targets[k] = dataset_y[j * batch_size + k]
+        # Note: numpy correctly handles the size of the last minibatch.
+        mini_batch_input = dataset_x[j*batch_size : (j+1)*batch_size].astype(th.config.floatX)
+        mini_batch_targets = dataset_y[j*batch_size : (j+1)*batch_size].astype(th.config.floatX)
 
         mini_batch_prediction = np.argmax(model.forward(mini_batch_input), axis=1)
 
-        if (j + 1) * batch_size > dataset_x.shape[0]:
-            mini_batch_prediction.resize((dataset_x.shape[0] - j * batch_size, ))
-            mini_batch_targets.resize((dataset_x.shape[0] - j * batch_size, ))
-
         nerrors += sum(mini_batch_targets != mini_batch_prediction)
+
+        progress.update(j * batch_size)
 
     progress.finish()
     accuracy = 1 - float(nerrors)/dataset_x.shape[0]

--- a/examples/MNIST/train.py
+++ b/examples/MNIST/train.py
@@ -1,5 +1,5 @@
 import numpy as np
-import theano as _th
+import theano as th
 
 from examples.utils import make_progressbar
 
@@ -10,13 +10,10 @@ def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, 
 
     shuffle = np.random.permutation(len(dataset_x))
 
-    mini_batch_input = np.empty(shape=(batch_size, 28*28), dtype=_th.config.floatX)
-    mini_batch_targets = np.empty(shape=(batch_size, ), dtype=_th.config.floatX)
-
     for j in range(dataset_x.shape[0] // batch_size):
-        for k in range(batch_size):
-            mini_batch_input[k] = dataset_x[shuffle[j * batch_size + k]]
-            mini_batch_targets[k] = dataset_y[shuffle[j * batch_size + k]]
+        indices = shuffle[j*batch_size : (j+1)*batch_size]
+        mini_batch_input = dataset_x[indices].astype(th.config.floatX)
+        mini_batch_targets = dataset_y[indices].astype(th.config.floatX)
 
         if mode == 'train':
             model.zero_grad_parameters()
@@ -27,6 +24,6 @@ def train(dataset_x, dataset_y, model, optimiser, criterion, epoch, batch_size, 
         else:
             assert False, "Mode should be either 'train' or 'stats'"
 
-        progress.update((j+1) * batch_size)
+        progress.update(j*batch_size + len(mini_batch_input))
 
     progress.finish()


### PR DESCRIPTION
This makes use of the fact that [numpy array slicing works just like python slicing](http://docs.scipy.org/doc/numpy/user/basics.indexing.html#other-indexing-options), which will just "go to the end" when the slicing value is out-of-bounds. (See the "word[4:42]" example in the [python intro](https://docs.python.org/2/tutorial/introduction.html).) I think that makes the examples considerably easier to read.

Note that during training it still will not use the last smaller minibatch since that would influence batch-normalization much more, I wanted to have your opinion on it.
